### PR TITLE
Allow uncaught errors, and generic event return values

### DIFF
--- a/src/config/epsilon-lambda-event-handler.ts
+++ b/src/config/epsilon-lambda-event-handler.ts
@@ -4,4 +4,5 @@ export interface EpsilonLambdaEventHandler<T> {
   handlesEvent(evt: any): boolean;
   extractLabel(evt: T, context: Context): string;
   processEvent(evt: T, context: Context): Promise<ProxyResult>;
+  allowUncaughtErrors?(): boolean;
 }

--- a/src/config/generic-aws-event-handler-function.ts
+++ b/src/config/generic-aws-event-handler-function.ts
@@ -1,3 +1,3 @@
 export interface GenericAwsEventHandlerFunction<T> {
-  (event: T): Promise<void>;
+  (event: T): Promise<any>;
 }

--- a/src/lambda-event-handler/dynamo-epsilon-lambda-event-handler.ts
+++ b/src/lambda-event-handler/dynamo-epsilon-lambda-event-handler.ts
@@ -32,4 +32,10 @@ export class DynamoEpsilonLambdaEventHandler implements EpsilonLambdaEventHandle
     }
     return rval;
   }
+
+  // For DynamoDB event stream events, we want errors to be raised to Lambda, so it
+  // knows to retry if an uncaught processing error occurs.
+  public allowUncaughtErrors(): boolean {
+    return true;
+  }
 }


### PR DESCRIPTION
This allows for lambda event handlers to optionally indicate that uncaught errors should be allowed (not caught and returned as HTTP 500s).

It also allows for `GenericAwsEventHandlerFunction` event functions to return a value, which will be necessary for [batch failure reporting](https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-batchfailurereporting).