### PR TITLE
Stop http/s server on SIGINT

### DIFF
--- a/src/local-server.ts
+++ b/src/local-server.ts
@@ -40,6 +40,7 @@ export class LocalServer {
         process.on('SIGINT', () => {
           Logger.info('Caught SIGINT - shutting down test server...');
           this.aborted = true;
+          this.server.close();
           res(true);
         });
       } catch (err) {


### PR DESCRIPTION
When running a `LocalServer` and stopping it via SIGINT (e.g. Ctrl+C), the HTTP/S server seems to keep running in the background and holding onto the listening port. This ensure it gets shut down so it can be re-run immediately with the same listening port.