### PR TITLE
Modify fireImmediateProcessRequest to match the error handling behavior of addEntryToQueue.

### DIFF
--- a/src/background/manager/aws-sqs-sns-background-manager.ts
+++ b/src/background/manager/aws-sqs-sns-background-manager.ts
@@ -86,10 +86,9 @@ export class AwsSqsSnsBackgroundManager extends AbstractBackgroundManager {
   }
 
   public async fireImmediateProcessRequest<T>(entry: BackgroundEntry<T>): Promise<string> {
-    let rval: string = null;
-    const wrapped: InternalBackgroundEntry<T> = this.wrapEntryForInternal(entry);
-    rval = wrapped.guid;
     try {
+      const wrapped: InternalBackgroundEntry<T> = this.wrapEntryForInternal(entry);
+      const rval: string = wrapped.guid;
       // Guard against bad entries up front
       Logger.info('Fire immediately (remote) : %j ', entry);
       const toWrite: any = {
@@ -99,10 +98,11 @@ export class AwsSqsSnsBackgroundManager extends AbstractBackgroundManager {
       const msg: string = JSON.stringify(toWrite);
       const snsId: string = await this.writeMessageToSnsTopic(msg);
       Logger.debug('Background guid %s Wrote message : %s to SNS : %s', rval, msg, snsId);
+      return rval;
     } catch (err) {
       Logger.error('Failed to fireImmediateProcessRequest : %s', err, err);
+      throw new Error('Failed to fireImmediateProcessRequest : : ' + err['code'] + ' : ' + err['name']);
     }
-    return rval;
   }
 
   public async fireStartProcessingRequest(): Promise<string> {


### PR DESCRIPTION
fireImmediateProcessRequest is always returning a guid even if it failed to send the message. 

Now it'll rethrow any exceptions/errors so that the calling function can handle them.