### PR TITLE
Add support for large background task payloads by sending to s3

### DIFF
--- a/src/background/background-handler.ts
+++ b/src/background/background-handler.ts
@@ -270,6 +270,7 @@ export class BackgroundHandler implements EpsilonLambdaEventHandler<SNSEvent> {
     Logger.info('Background Process Start: %j', e);
     const sw: StopWatch = new StopWatch();
     await this.conditionallyStartTransactionLog(e);
+    await this.mgr.populateInternalEntry(e);
     let rval: boolean = false;
     try {
       await this.fireListenerEvent({

--- a/src/background/background-validator.ts
+++ b/src/background/background-validator.ts
@@ -85,6 +85,9 @@ export class BackgroundValidator {
       ) {
         rval.push('At least one send notification flag set to true but no sns arn set');
       }
+      if (cfg.sendLargePayloadsToS3 && !(cfg.s3Bucket && cfg.s3BucketPath)) {
+        rval.push('If sendLargePayloadsToS3, then both s3Bucket and s3BucketPath must be defined');
+      }
     }
     return rval;
   }

--- a/src/background/internal-background-entry.ts
+++ b/src/background/internal-background-entry.ts
@@ -5,4 +5,7 @@ export interface InternalBackgroundEntry<T> extends BackgroundEntry<T> {
   createdEpochMS: number;
   traceId: string;
   traceDepth: number;
+
+  getDataFromS3?: boolean;
+  pathToDataInS3?: string;
 }

--- a/src/background/manager/abstract-background-manager.ts
+++ b/src/background/manager/abstract-background-manager.ts
@@ -19,6 +19,7 @@ export abstract class AbstractBackgroundManager implements BackgroundManagerLike
   abstract fetchApproximateNumberOfQueueEntries(): Promise<number>;
   abstract get backgroundManagerName(): string;
   abstract takeEntryFromBackgroundQueue(): Promise<InternalBackgroundEntry<any>[]>;
+  abstract populateInternalEntry<T>(entry: InternalBackgroundEntry<T>): Promise<InternalBackgroundEntry<T>>;
 
   public createEntry<T>(type: string, data?: T): BackgroundEntry<T> {
     const rval: BackgroundEntry<T> = {

--- a/src/background/manager/aws-sqs-sns-background-manager.ts
+++ b/src/background/manager/aws-sqs-sns-background-manager.ts
@@ -20,6 +20,7 @@ import { InternalBackgroundEntry } from '../internal-background-entry';
 import { AbstractBackgroundManager } from './abstract-background-manager';
 import { BackgroundValidator } from '../background-validator';
 import { PublishCommand, PublishCommandOutput, SNSClient } from '@aws-sdk/client-sns';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
 /**
  * Handles all submission of work to the background processing system.
@@ -29,15 +30,22 @@ import { PublishCommand, PublishCommandOutput, SNSClient } from '@aws-sdk/client
  * define the type and validation.
  */
 export class AwsSqsSnsBackgroundManager extends AbstractBackgroundManager {
+  // SQS and SNS payload limit is (256 * 1024). Set threshold lower to allow extra metadata
+  private static readonly LARGE_MESSAGE_SIZE_THRESHOLD: number = 250_000;
+
   constructor(
     private _awsConfig: BackgroundAwsConfig,
     private _sqs: SQSClient,
     private _sns: SNSClient,
+    private _s3Client?: S3Client,
   ) {
     super();
     const cfgErrors: string[] = BackgroundValidator.validateAwsConfig(_awsConfig);
     if (cfgErrors.length) {
       ErrorRatchet.throwFormattedErr('Cannot start - invalid AWS config : %j', cfgErrors);
+    }
+    if (_awsConfig.sendLargePayloadsToS3 && !_s3Client) {
+      ErrorRatchet.throwFormattedErr('Cannot start - sendLargePayloadsToS3 is set but no s3Client provided');
     }
   }
 
@@ -62,6 +70,7 @@ export class AwsSqsSnsBackgroundManager extends AbstractBackgroundManager {
       const wrapped: InternalBackgroundEntry<T> = this.wrapEntryForInternal(entry);
       const rval: string = wrapped.guid;
       // Guard against bad entries up front
+      await this.processMessageForLargePayload(wrapped);
       const params = {
         DelaySeconds: 0,
         MessageBody: JSON.stringify(wrapped),
@@ -92,6 +101,7 @@ export class AwsSqsSnsBackgroundManager extends AbstractBackgroundManager {
     try {
       // Guard against bad entries up front
       Logger.info('Fire immediately (remote) : %j ', entry);
+      await this.processMessageForLargePayload(wrapped);
       const toWrite: any = {
         type: EpsilonConstants.BACKGROUND_SNS_IMMEDIATE_RUN_FLAG,
         backgroundEntry: wrapped,
@@ -185,5 +195,43 @@ export class AwsSqsSnsBackgroundManager extends AbstractBackgroundManager {
     }
 
     return rval;
+  }
+
+  private async processMessageForLargePayload<T>(wrapped: InternalBackgroundEntry<T>): Promise<void> {
+    const payloadApproximateSize: number = Buffer.byteLength(JSON.stringify(wrapped), 'utf-8');
+    if (payloadApproximateSize > AwsSqsSnsBackgroundManager.LARGE_MESSAGE_SIZE_THRESHOLD) {
+      if (this._awsConfig.sendLargePayloadsToS3) {
+        Logger.info('Message payload is above LARGE_MESSAGE_SIZE_THRESHOLD. Uploading to s3.');
+        wrapped.pathToDataInS3 = await this.writeMessageToS3(wrapped.guid, wrapped.data);
+        wrapped.data = undefined;
+        wrapped.getDataFromS3 = true;
+      } else {
+        Logger.warn('Message payload is above LARGE_MESSAGE_SIZE_THRESHOLD but sendLargePayloadsToS3 is not set.');
+      }
+    }
+  }
+
+  private async writeMessageToS3(guid: string, entry: unknown): Promise<string> {
+    const s3FilePath: string = `${this._awsConfig.s3BucketPath}/${guid}.json`;
+    const putCommand = new PutObjectCommand({
+      Bucket: this._awsConfig.s3Bucket,
+      Key: s3FilePath,
+      Body: JSON.stringify(entry),
+    });
+    await this._s3Client.send(putCommand);
+    return s3FilePath;
+  }
+
+  public async populateInternalEntry<T>(entry: InternalBackgroundEntry<T>): Promise<InternalBackgroundEntry<T>> {
+    if (entry.getDataFromS3) {
+      const getCommand = new GetObjectCommand({
+        Bucket: this._awsConfig.s3Bucket,
+        Key: entry.pathToDataInS3,
+      });
+      const getObjectCommandOutput = await this._s3Client.send(getCommand);
+      const bodyString: string = await getObjectCommandOutput.Body.transformToString();
+      entry.data = JSON.parse(bodyString);
+    }
+    return entry;
   }
 }

--- a/src/background/manager/background-manager-like.ts
+++ b/src/background/manager/background-manager-like.ts
@@ -34,4 +34,6 @@ export interface BackgroundManagerLike {
   fetchApproximateNumberOfQueueEntries(): Promise<number>;
   // Read a single entry from the background queue
   takeEntryFromBackgroundQueue(): Promise<InternalBackgroundEntry<any>[]>;
+  // Allows repopulating any externally stored data after the entry is pulled and parsed from the queue
+  populateInternalEntry<T>(entry: InternalBackgroundEntry<T>): Promise<InternalBackgroundEntry<T>>;
 }

--- a/src/background/manager/single-thread-local-background-manager.ts
+++ b/src/background/manager/single-thread-local-background-manager.ts
@@ -60,4 +60,8 @@ export class SingleThreadLocalBackgroundManager extends AbstractBackgroundManage
     Logger.info('Called takeEntryFromBackgroundQueue on SingleThreadedLocal - returning empty');
     return [];
   }
+
+  public async populateInternalEntry<T>(entry: InternalBackgroundEntry<T>): Promise<InternalBackgroundEntry<T>> {
+    return entry;
+  }
 }

--- a/src/config/background/background-aws-config.ts
+++ b/src/config/background/background-aws-config.ts
@@ -5,4 +5,8 @@ export interface BackgroundAwsConfig {
   sendNotificationOnBackgroundValidationFailure?: boolean;
   // If either of the above are set to true, notifications will be sent here
   backgroundProcessFailureSnsArn?: string;
+
+  sendLargePayloadsToS3?: boolean;
+  s3Bucket?: string;
+  s3BucketPath?: string;
 }


### PR DESCRIPTION
Adds the sendLargePayloadsToS3 option to AwsSqsSnsBackgroundManager. If set, s3Bucket, s3BucketPath must also be set and a S3Client passed in.

If the option is enabled, any background task data that is > LARGE_MESSAGE_SIZE_THRESHOLD will be stored in the specified s3 bucket. The data will be read back from s3 when the message is pulled.

Any downstream projects not using sendLargePayloadsToS3 do not need to be updated.
Projects using sendLargePayloadsToS3 will need to enable lifecycle rules on the target bucket/path to clean up stored messages.