### PR TITLE
Optionally allow manipulator errors to be included in HTTP responses

### DIFF
--- a/src/built-in/http/built-in-auth-filters.ts
+++ b/src/built-in/http/built-in-auth-filters.ts
@@ -88,6 +88,9 @@ export class BuiltInAuthFilters {
             auth: null,
             error: err['message'],
           };
+          fCtx.allowManipulatorErrorMessagesInResponses = manipulator.allowErrorMessagesInResponses
+            ? manipulator.allowErrorMessagesInResponses()
+            : false;
         }
       }
     }
@@ -106,7 +109,11 @@ export class BuiltInAuthFilters {
             throw new ForbiddenError('You lack privileges to see this endpoint');
           }
         } else {
-          throw new UnauthorizedError('You need to supply credentials for this endpoint');
+          throw new UnauthorizedError(
+            fCtx.allowManipulatorErrorMessagesInResponses
+              ? fCtx.event.authorization.error
+              : 'You need to supply credentials for this endpoint',
+          );
         }
       } else {
         throw new MisconfiguredError().withFormattedErrorMessage(

--- a/src/config/http/filter-chain-context.ts
+++ b/src/config/http/filter-chain-context.ts
@@ -12,4 +12,5 @@ export interface FilterChainContext {
   routeAndParse: RouteAndParse;
   modelValidator: ModelValidator;
   authenticators: Map<string, AuthorizerFunction>;
+  allowManipulatorErrorMessagesInResponses?: boolean;
 }

--- a/src/http/auth/web-token-manipulator.ts
+++ b/src/http/auth/web-token-manipulator.ts
@@ -5,4 +5,5 @@ import { JwtTokenBase } from '@bitblit/ratchet/common';
 
 export interface WebTokenManipulator<T extends JwtTokenBase> {
   extractTokenFromAuthorizationHeader(header: string): Promise<T>;
+  allowErrorMessagesInResponses?(): boolean;
 }


### PR DESCRIPTION
As it is currently, if a `WebTokenManipulator` throws any error, regardless of the error, the same message ("You need to supply credentials for this endpoint") is returned in the HTTP response.

That's a reasonable and secure default, but when appropriate, it may be reasonable to return the error message generated by the manipulator in the HTTP response.

This adds an optional method (`allowErrorMessagesInResponses?(): boolean`) to the `WebTokenManipulator` interface. If a `WebTokenManipulator` throws an error and returns `true` for that method, its error message is included in the HTTP response. If the method is not implemented (or returns `false`), it falls back to the original behavior. In this way, it's backward compatible. The new functionality only happens if the new method is implemented.