### PR TITLE
Add prototypes to http errors

### DIFF
--- a/src/http/error/bad-gateway.ts
+++ b/src/http/error/bad-gateway.ts
@@ -5,6 +5,7 @@ export class BadGateway<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, BadGateway.prototype);
     this.withHttpStatusCode(BadGateway.HTTP_CODE);
   }
 }

--- a/src/http/error/bad-request-error.ts
+++ b/src/http/error/bad-request-error.ts
@@ -5,6 +5,7 @@ export class BadRequestError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, BadRequestError.prototype);
     this.withHttpStatusCode(BadRequestError.HTTP_CODE);
   }
 }

--- a/src/http/error/conflict-error.ts
+++ b/src/http/error/conflict-error.ts
@@ -5,6 +5,7 @@ export class ConflictError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, ConflictError.prototype);
     this.withHttpStatusCode(ConflictError.HTTP_CODE);
   }
 }

--- a/src/http/error/forbidden-error.ts
+++ b/src/http/error/forbidden-error.ts
@@ -5,6 +5,7 @@ export class ForbiddenError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, ForbiddenError.prototype);
     this.withHttpStatusCode(ForbiddenError.HTTP_CODE);
   }
 }

--- a/src/http/error/gateway-timeout.ts
+++ b/src/http/error/gateway-timeout.ts
@@ -5,6 +5,7 @@ export class GatewayTimeout<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, GatewayTimeout.prototype);
     this.withHttpStatusCode(GatewayTimeout.HTTP_CODE);
   }
 }

--- a/src/http/error/method-not-allowed-error.ts
+++ b/src/http/error/method-not-allowed-error.ts
@@ -5,6 +5,7 @@ export class MethodNotAllowedError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, MethodNotAllowedError.prototype);
     this.withHttpStatusCode(MethodNotAllowedError.HTTP_CODE);
   }
 }

--- a/src/http/error/misconfigured-error.ts
+++ b/src/http/error/misconfigured-error.ts
@@ -5,6 +5,7 @@ export class MisconfiguredError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, MisconfiguredError.prototype);
     this.withHttpStatusCode(MisconfiguredError.HTTP_CODE);
   }
 }

--- a/src/http/error/not-found-error.ts
+++ b/src/http/error/not-found-error.ts
@@ -5,6 +5,7 @@ export class NotFoundError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, NotFoundError.prototype);
     this.withHttpStatusCode(NotFoundError.HTTP_CODE);
   }
 }

--- a/src/http/error/not-implemented.ts
+++ b/src/http/error/not-implemented.ts
@@ -5,6 +5,7 @@ export class NotImplemented<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, NotImplemented.prototype);
     this.withHttpStatusCode(NotImplemented.HTTP_CODE);
   }
 }

--- a/src/http/error/request-timeout-error.ts
+++ b/src/http/error/request-timeout-error.ts
@@ -5,6 +5,7 @@ export class RequestTimeoutError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, RequestTimeoutError.prototype);
     this.withHttpStatusCode(RequestTimeoutError.HTTP_CODE);
   }
 }

--- a/src/http/error/service-unavailable.ts
+++ b/src/http/error/service-unavailable.ts
@@ -5,6 +5,7 @@ export class ServiceUnavailable<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, ServiceUnavailable.prototype);
     this.withHttpStatusCode(ServiceUnavailable.HTTP_CODE);
   }
 }

--- a/src/http/error/too-many-requests-error.ts
+++ b/src/http/error/too-many-requests-error.ts
@@ -5,6 +5,7 @@ export class TooManyRequestsError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, TooManyRequestsError.prototype);
     this.withHttpStatusCode(TooManyRequestsError.HTTP_CODE);
   }
 }

--- a/src/http/error/unauthorized-error.ts
+++ b/src/http/error/unauthorized-error.ts
@@ -5,6 +5,7 @@ export class UnauthorizedError<T = void> extends RestfulApiHttpError<T> {
 
   constructor(...errors: string[]) {
     super(...errors);
+    Object.setPrototypeOf(this, UnauthorizedError.prototype);
     this.withHttpStatusCode(UnauthorizedError.HTTP_CODE);
   }
 }


### PR DESCRIPTION
This adds `Object.setPrototypeOf` calls to the HTTP errors. Apparently this is necessary for the Typescript syntax like this to work:

```
if (err instanceof BadRequestError) {
```