### PR TITLE
Fixed handling of url decoding query values, plus symbol

### DIFF
--- a/src/built-in/http/built-in-filters.spec.ts
+++ b/src/built-in/http/built-in-filters.spec.ts
@@ -1,0 +1,25 @@
+import { ExtendedAPIGatewayEvent } from 'config/http/extended-api-gateway-event';
+import { BuiltInFilters } from './built-in-filters';
+import { FilterChainContext } from 'config/http/filter-chain-context';
+
+describe('#uriDecodeQueryParams', function () {
+  it('should not URL decode query string parameters', async () => {
+    const queryParams: { [key: string]: string } = {
+      test: 'fish+chips',
+      test2: 'chicken%2bbeef',
+      test3: 'ketchup%20mustard',
+      test4: '',
+      test5: 'cat=dog',
+    };
+
+    BuiltInFilters.uriDecodeQueryParams({
+      event: { queryStringParameters: queryParams } as ExtendedAPIGatewayEvent,
+    } as FilterChainContext);
+
+    expect(queryParams['test']).toBe('fish chips');
+    expect(queryParams['test2']).toBe('chicken+beef');
+    expect(queryParams['test3']).toBe('ketchup mustard');
+    expect(queryParams['test4']).toBe('');
+    expect(queryParams['test5']).toBe('cat=dog');
+  });
+});

--- a/src/built-in/http/built-in-filters.ts
+++ b/src/built-in/http/built-in-filters.ts
@@ -72,7 +72,7 @@ export class BuiltInFilters {
       Object.keys(fCtx.event.queryStringParameters).forEach((k) => {
         const val: string = fCtx.event.queryStringParameters[k];
         if (val) {
-          fCtx.event.queryStringParameters[k] = decodeURIComponent(val);
+          fCtx.event.queryStringParameters[k] = BuiltInFilters.decodeUriComponentAndReplacePlus(val);
         }
       });
     }
@@ -80,12 +80,19 @@ export class BuiltInFilters {
       Object.keys(fCtx.event.multiValueQueryStringParameters).forEach((k) => {
         const val: string[] = fCtx.event.multiValueQueryStringParameters[k];
         if (val && val.length) {
-          const cleaned: string[] = val.map((v) => decodeURIComponent(v));
+          const cleaned: string[] = val.map((v) => BuiltInFilters.decodeUriComponentAndReplacePlus(v));
           fCtx.event.multiValueQueryStringParameters[k] = cleaned;
         }
       });
     }
     return true;
+  }
+
+  /**
+   * Performs decodeURIComponent on a value after replacing all "+" values with spaces.
+   */
+  private static decodeUriComponentAndReplacePlus(val: string): string {
+    return decodeURIComponent(val.replace(/\+/g, ' '));
   }
 
   public static async fixStillEncodedQueryParams(fCtx: FilterChainContext): Promise<boolean> {

--- a/src/local-server.spec.ts
+++ b/src/local-server.spec.ts
@@ -1,0 +1,15 @@
+import { LocalServer } from './local-server';
+
+describe('#localServer', function () {
+  it('should not URL decode query string parameters', async () => {
+    const queryParams: { [key: string]: string } = LocalServer.parseQueryParamsFromUrlString(
+      'http://localhost?test=fish+chips&test2=chicken%2bbeef&test3=ketchup%20mustard&test4=&test5=cat=dog',
+    );
+
+    expect(queryParams['test']).toBe('fish+chips');
+    expect(queryParams['test2']).toBe('chicken%2bbeef');
+    expect(queryParams['test3']).toBe('ketchup%20mustard');
+    expect(queryParams['test4']).toBe('');
+    expect(queryParams['test5']).toBe('cat=dog');
+  });
+});

--- a/src/sample/sample-server-components.ts
+++ b/src/sample/sample-server-components.ts
@@ -107,6 +107,13 @@ export class SampleServerComponents {
     handlers.set('post /secure/access-token', (event) => BuiltInHandlers.sample(event));
     handlers.set('get /multi/fixed', (event) => BuiltInHandlers.sample(event, 'fixed'));
     handlers.set('get /multi/{v}', (event) => BuiltInHandlers.sample(event, 'variable'));
+    handlers.set('get /event', (event) => {
+      return Promise.resolve({
+        statusCode: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(event, null, 2),
+      });
+    });
     handlers.set('get /err/{code}', (event) => {
       const err: Error = ErrorRatchet.fErr('Fake Err : %j', event);
       err['statusCode'] = NumberRatchet.safeNumber(event.pathParameters['code']);

--- a/src/sample/sample-server-static-files.ts
+++ b/src/sample/sample-server-static-files.ts
@@ -31,6 +31,21 @@ export class SampleServerStaticFiles {
     '      responses:\n' +
     "        '200':\n" +
     '          description: Standard CORS header response\n' +
+    '  /event:\n' +
+    '    get:\n' +
+    '      description: Tests URL parsing and returns event as JSON\n' +
+    '      tags:\n' +
+    '        - Meta\n' +
+    '        - Public\n' +
+    '      responses:\n' +
+    "        '200':\n" +
+    '          description: The parsed event, as JSON\n' +
+    '    options:\n' +
+    '      tags:\n' +
+    '        - CORS\n' +
+    '      responses:\n' +
+    "        '200':\n" +
+    '          description: Standard CORS header response\n' +
     '  /meta/server:\n' +
     '    get:\n' +
     '      description: >\n' +


### PR DESCRIPTION
I did a bit of a "deep dive" on the `+` URL encoding / decoding issue this morning that I think I mentioned a few weeks ago.

Note that:
 - Without Epsilon, and just using a plain ALB -> Lambda integration, URL query parameters are **not** decoded. You get the "+" and percent-encoded values just as they appear in the URL string

There are two root issues:
 - When running Epsilon locally, it's doing URL decoding of query parameters on its own. But that's in addition to the `BuiltInFilters.uriDecodeQueryParams` function, which also does that by default
 - The `BuiltInFilters.uriDecodeQueryParams` function does perform decoding of the query parameters, but does not convert `+` values to spaces.

In practice, that means that when I see a plus `+` symbol in a query value, I can't tell whether the user intended to send me a plus symbol or it's just a space, because in both cases I just get a `+` in the decoded value.

This PR:
 - Removes the URL decoding of query parameters as part of running Epsilon locally
 - Adds conversion of unencoded `+` symbols included in query string parameter values to spaces during the `BuiltInFilters.uriDecodeQueryParams` function
 - Adds unit tests to confirm functionality in both places
 - Adds a new endpoint to the sample local server that just returns the parsed event as JSON (for easy debugging / troubleshooting)

The net result is that Epsilon will still do URL decoding of parameter values (assuming it has that filter enabled), but will properly replace `+` symbols with spaces. And if running locally, its URL decoding behavior will be no different than when it runs on Lambda (no additional URL parameter decoding step that ALB -> Lambda doesn't do).

I think this should be mostly backward-compatible, except for any consumers that were otherwise doing weird steps to work around the pre-existing behavior.