### PR TITLE
Redact auth tokens in logged events

### DIFF
--- a/src/built-in/http/run-handler-as-filter.spec.ts
+++ b/src/built-in/http/run-handler-as-filter.spec.ts
@@ -48,4 +48,19 @@ describe('#routerUtilApplyOpenApiDoc', function () {
     const outString: string = RouterUtil.openApiPathToRouteParserPath(inString);
     expect(outString).toEqual('/meta/item/:itemId');
   });
+
+  it('should redact authorization values from events for logging', function () {
+    const inputEvent: any = {
+      authorization: {
+        raw: 'secret-access-token-here',
+      },
+      headers: {
+        authorization: 'Bearer secret-access-token-here',
+      },
+    };
+    // @ts-expect-error private method
+    const logEventObj: any = JSON.parse(RunHandlerAsFilter.eventToStringForLog(inputEvent));
+    expect(logEventObj.authorization.raw).toEqual(RunHandlerAsFilter.REDACTED_STRING);
+    expect(logEventObj.headers.authorization).toEqual(RunHandlerAsFilter.REDACTED_STRING);
+  });
 });


### PR DESCRIPTION
Just before logging an event as part of a timeout, this removes the `authorization` header value, and the `raw` parsed authorization value. Normally these would contain secret access tokens not suitable for a log.